### PR TITLE
update to alpine3.5 and nginx 1.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache nginx bash && \


### PR DESCRIPTION
- the nginx version 1.10.2 in alpine3.5 comes with the
http_realip_module module compiled in. This module is used to
whitelist/blacklist on proxyprotocol set ips from upstream
loadbalancers.