### PR TITLE
Run the script using CMD instead of ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY conf.d /etc/nginx/conf.d
 # UID for nginx user
 USER 100
 
-ENTRYPOINT ["/run.sh"]
+CMD ["/run.sh"]


### PR DESCRIPTION
The script is not a proper ENTRYPOINT script - it doesn't use the parameters passed by CMD, which means it's tricky to run arbitrary commands (like sh) for debugging/development purposes.

After changing to CMD, you can do `docker run -it ...nginx sh` successfully, or `docker run ...nginx` to run the script as before.